### PR TITLE
Improve update_or_create shortcut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## ??? ##
 
+## 2.0.2 ##
+
+### CHANGE ###
+
+- `pik.core.shortcuts: update_or_create_object` function now support Model, QuerySet and Manager as first argument. It might be useful if you are trying to update deleted objects (SoftDeleted)  
+
 ## 2.0.1 ##
 
 ### CHANGE ###

--- a/pik/core/shortcuts/model_objects.py
+++ b/pik/core/shortcuts/model_objects.py
@@ -101,13 +101,15 @@ def validate_and_update_object(obj: models.Model, **kwargs) \
 def update_or_create_object(
         model: Type[models.Model],
         search_keys: Optional[dict] = None,
+        queryset_or_manager: Union[models.QuerySet, models.Manager] = None,
         **kwargs) \
         -> Tuple[models.Model, List[str], bool]:
     """
     :raises ValueError
     :return obj, is_updated, is_created
     """
-    obj = get_object_or_none(model, **search_keys) if search_keys else None
+    source = queryset_or_manager or model
+    obj = get_object_or_none(source, **search_keys) if search_keys else None
     if obj:
         is_created = False
         obj, updates = validate_and_update_object(obj, **kwargs)

--- a/pik/core/shortcuts/model_objects.py
+++ b/pik/core/shortcuts/model_objects.py
@@ -101,14 +101,14 @@ def validate_and_update_object(obj: models.Model, **kwargs) \
 def update_or_create_object(
         model: Type[models.Model],
         search_keys: Optional[dict] = None,
-        queryset: models.QuerySet = None,
+        queryset_or_manager: Union[models.QuerySet, models.Manager] = None,
         **kwargs) \
         -> Tuple[models.Model, List[str], bool]:
     """
     :raises ValueError
     :return obj, is_updated, is_created
     """
-    source = queryset or model
+    source = queryset_or_manager or model
     obj = get_object_or_none(source, **search_keys) if search_keys else None
     if obj:
         is_created = False

--- a/pik/core/shortcuts/model_objects.py
+++ b/pik/core/shortcuts/model_objects.py
@@ -99,16 +99,22 @@ def validate_and_update_object(obj: models.Model, **kwargs) \
 
 
 def update_or_create_object(
-        model: Type[models.Model],
+        source: Union[Type[models.Model], models.QuerySet, models.Manager],
         search_keys: Optional[dict] = None,
-        queryset_or_manager: Union[models.QuerySet, models.Manager] = None,
         **kwargs) \
         -> Tuple[models.Model, List[str], bool]:
     """
     :raises ValueError
     :return obj, is_updated, is_created
     """
-    source = queryset_or_manager or model
+    assert (isinstance(source, (models.QuerySet, models.Manager))
+            or issubclass(source, models.Model))
+
+    if not isinstance(source, (models.QuerySet, models.Manager)):
+        model = source
+        source = source.objects
+    else:
+        model = source.model
     obj = get_object_or_none(source, **search_keys) if search_keys else None
     if obj:
         is_created = False

--- a/pik/core/shortcuts/model_objects.py
+++ b/pik/core/shortcuts/model_objects.py
@@ -110,11 +110,10 @@ def update_or_create_object(
     assert (isinstance(source, (models.QuerySet, models.Manager))
             or issubclass(source, models.Model))
 
-    if not isinstance(source, (models.QuerySet, models.Manager)):
-        model = source
-        source = source.objects
-    else:
+    model = source
+    if isinstance(source, (models.QuerySet, models.Manager)):
         model = source.model
+
     obj = get_object_or_none(source, **search_keys) if search_keys else None
     if obj:
         is_created = False

--- a/pik/core/shortcuts/model_objects.py
+++ b/pik/core/shortcuts/model_objects.py
@@ -101,14 +101,14 @@ def validate_and_update_object(obj: models.Model, **kwargs) \
 def update_or_create_object(
         model: Type[models.Model],
         search_keys: Optional[dict] = None,
-        queryset_or_manager: Union[models.QuerySet, models.Manager] = None,
+        queryset: models.QuerySet = None,
         **kwargs) \
         -> Tuple[models.Model, List[str], bool]:
     """
     :raises ValueError
     :return obj, is_updated, is_created
     """
-    source = queryset_or_manager or model
+    source = queryset or model
     obj = get_object_or_none(source, **search_keys) if search_keys else None
     if obj:
         is_created = False

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open(path.join(here, 'requirements.dev.txt'), encoding='utf-8') as f:
 
 setup(
     name='pik-django-utils',
-    version='2.0.1',
+    version='2.0.2',
     description='Common PIK Django utils and tools',
     # https://packaging.python.org/specifications/core-metadata/#description-optional
     long_description=long_description,

--- a/test_core_shortcuts/models/base.py
+++ b/test_core_shortcuts/models/base.py
@@ -16,7 +16,7 @@ class MyModelQuerySet(models.QuerySet):
     pass
 
 
-class ModelWithOverriddenQueryset(BasePHistorical):
+class OverriddenQuerysetModel(BasePHistorical):
     name = models.CharField(max_length=255)
 
     test_objects = MyModelQuerySet().as_manager()

--- a/test_core_shortcuts/models/base.py
+++ b/test_core_shortcuts/models/base.py
@@ -10,3 +10,9 @@ class TestNameModel(BasePHistorical):
 class MySimpleModel(BasePHistorical):
     data = models.CharField(max_length=255)
     names = models.ManyToManyField(TestNameModel, blank=True)
+
+
+class ModelWithOverriddenQueryset(BasePHistorical):
+    name = models.CharField(max_length=255)
+
+    test_objects = BasePHistorical.objects

--- a/test_core_shortcuts/models/base.py
+++ b/test_core_shortcuts/models/base.py
@@ -12,7 +12,12 @@ class MySimpleModel(BasePHistorical):
     names = models.ManyToManyField(TestNameModel, blank=True)
 
 
+class MyModelManager(models.Manager):
+    def get_queryset(self):
+        return super().get_queryset()
+
+
 class ModelWithOverriddenQueryset(BasePHistorical):
     name = models.CharField(max_length=255)
 
-    test_objects = BasePHistorical.objects
+    test_objects = MyModelManager()

--- a/test_core_shortcuts/models/base.py
+++ b/test_core_shortcuts/models/base.py
@@ -12,12 +12,11 @@ class MySimpleModel(BasePHistorical):
     names = models.ManyToManyField(TestNameModel, blank=True)
 
 
-class MyModelManager(models.Manager):
-    def get_queryset(self):
-        return super().get_queryset()
+class MyModelQuerySet(models.QuerySet):
+    pass
 
 
 class ModelWithOverriddenQueryset(BasePHistorical):
     name = models.CharField(max_length=255)
 
-    test_objects = MyModelManager()
+    test_objects = MyModelQuerySet().as_manager()

--- a/test_core_shortcuts/tests/factories.py
+++ b/test_core_shortcuts/tests/factories.py
@@ -1,6 +1,7 @@
 import factory
 from django.utils.crypto import get_random_string
 
+from test_core_shortcuts.models import ModelWithOverriddenQueryset
 from ..models import MySimpleModel, TestNameModel
 
 
@@ -24,3 +25,10 @@ class TestNameModelFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = TestNameModel
+
+
+class ModelWithOverriddenQuerysetFactory(factory.django.DjangoModelFactory):
+    name = factory.LazyFunction(get_random_string)
+
+    class Meta:
+        model = ModelWithOverriddenQueryset

--- a/test_core_shortcuts/tests/factories.py
+++ b/test_core_shortcuts/tests/factories.py
@@ -1,7 +1,7 @@
 import factory
 from django.utils.crypto import get_random_string
 
-from test_core_shortcuts.models import ModelWithOverriddenQueryset
+from test_core_shortcuts.models import OverriddenQuerysetModel
 from ..models import MySimpleModel, TestNameModel
 
 
@@ -27,8 +27,8 @@ class TestNameModelFactory(factory.django.DjangoModelFactory):
         model = TestNameModel
 
 
-class ModelWithOverriddenQuerysetFactory(factory.django.DjangoModelFactory):
+class OverriddenQuerysetModelFactory(factory.django.DjangoModelFactory):
     name = factory.LazyFunction(get_random_string)
 
     class Meta:
-        model = ModelWithOverriddenQueryset
+        model = OverriddenQuerysetModel

--- a/test_core_shortcuts/tests/test_model_objects_shortcuts.py
+++ b/test_core_shortcuts/tests/test_model_objects_shortcuts.py
@@ -8,8 +8,10 @@ from django.utils.crypto import get_random_string
 from pik.core.shortcuts import (
     get_object_or_none, validate_and_create_object, validate_and_update_object,
     update_or_create_object)
-from .factories import MySimpleModelFactory, TestNameModelFactory
-from ..models import MySimpleModel
+from .factories import (
+    MySimpleModelFactory, TestNameModelFactory,
+    ModelWithOverriddenQuerysetFactory)
+from ..models import MySimpleModel, ModelWithOverriddenQueryset
 
 
 @pytest.fixture(params=[
@@ -156,6 +158,20 @@ def test_update_or_create_object__no_update(test_model):
     assert not is_created
     assert name1 in res_obj.names.all()
     assert name2 in res_obj.names.all()
+
+
+def test_update_or_create_object_with_queryset():
+    obj = ModelWithOverriddenQuerysetFactory(name='Test')
+
+    new_name = 'New Name'
+    res_obj, is_updated, is_created = update_or_create_object(
+        ModelWithOverriddenQueryset, queryset_or_manager=obj.test_objects,
+        search_keys=dict(name=obj.name), **{'name': new_name})
+
+    assert is_updated
+
+    obj.refresh_from_db()
+    assert obj.name == new_name
 
 
 class TestNotCallM2MUpdate(TestCase):

--- a/test_core_shortcuts/tests/test_model_objects_shortcuts.py
+++ b/test_core_shortcuts/tests/test_model_objects_shortcuts.py
@@ -165,7 +165,7 @@ def test_update_or_create_object_with_queryset():
 
     new_name = 'New Name'
     res_obj, is_updated, is_created = update_or_create_object(
-        ModelWithOverriddenQueryset, queryset_or_manager=obj.test_objects,
+        ModelWithOverriddenQueryset, queryset=obj.test_objects,
         search_keys=dict(name=obj.name), **{'name': new_name})
 
     assert is_updated

--- a/test_core_shortcuts/tests/test_model_objects_shortcuts.py
+++ b/test_core_shortcuts/tests/test_model_objects_shortcuts.py
@@ -10,8 +10,8 @@ from pik.core.shortcuts import (
     update_or_create_object)
 from .factories import (
     MySimpleModelFactory, TestNameModelFactory,
-    ModelWithOverriddenQuerysetFactory)
-from ..models import MySimpleModel, ModelWithOverriddenQueryset
+    OverriddenQuerysetModelFactory)
+from ..models import MySimpleModel, OverriddenQuerysetModel
 
 
 @pytest.fixture(params=[
@@ -161,11 +161,11 @@ def test_update_or_create_object__no_update(test_model):
 
 
 def test_update_or_create_object_with_queryset():
-    obj = ModelWithOverriddenQuerysetFactory(name='Test')
+    obj = OverriddenQuerysetModelFactory(name='Test')
 
     new_name = 'New Name'
     res_obj, is_updated, is_created = update_or_create_object(
-        ModelWithOverriddenQueryset, queryset=obj.test_objects,
+        OverriddenQuerysetModel.test_objects,
         search_keys=dict(name=obj.name), **{'name': new_name})
 
     assert is_updated


### PR DESCRIPTION
Now you can add `queryset_or_manager` object to `update_or_create` shortcut like it implement in https://github.com/pik-software/pik-django-utils/blob/master/pik/core/shortcuts/model_objects.py#L27