### PR TITLE
Remove six

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## ??? ##
 
+## 2.0.5 ##
+
+### FIX ###
+
+- Remove django.six usage
+
 ## 2.0.4 ##
 
 ### FIX ###

--- a/pik/core/models/_collector_delete.py
+++ b/pik/core/models/_collector_delete.py
@@ -6,7 +6,6 @@ from django.db import transaction
 from django.db.models import signals, sql
 from django.db.models.deletion import Collector
 from django.db.models.fields.related import ForeignObject
-from django.utils import six
 from django.utils.translation import ugettext_lazy as _
 from django.conf import settings
 
@@ -75,18 +74,18 @@ def _delete(self):
             deleted_counter[qs.model._meta.label] += count
 
         # update fields
-        for model, instances_for_fieldvalues in six.iteritems(self.field_updates):
-            for (field, value), instances in six.iteritems(instances_for_fieldvalues):
+        for model, instances_for_fieldvalues in self.field_updates.items():
+            for (field, value), instances in instances_for_fieldvalues.items():
                 for obj in instances:
                     setattr(obj, field.name, value)
                     obj.save()
 
         # reverse instance collections
-        for instances in six.itervalues(self.data):
+        for instances in self.data.values():
             instances.reverse()
 
         # delete instances
-        for model, instances in six.iteritems(self.data):
+        for model, instances in self.data.items():
             if issubclass(model, SoftDeleted):
                 count = len(instances)
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open(path.join(here, 'requirements.dev.txt'), encoding='utf-8') as f:
 
 setup(
     name='pik-django-utils',
-    version='2.0.4',
+    version='2.0.5',
     description='Common PIK Django utils and tools',
     # https://packaging.python.org/specifications/core-metadata/#description-optional
     long_description=long_description,


### PR DESCRIPTION
We don't support python2, so we don't need six. Also it breaks django 3.0 compatible cause `django.six` was removed https://docs.djangoproject.com/en/3.0/releases/3.0/#removed-private-python-2-compatibility-apis