### PR TITLE
Consumer: make all queues auto-consume by setting RABBITMQ_CONSUMES='…

### DIFF
--- a/pik/api/lazy_field.py
+++ b/pik/api/lazy_field.py
@@ -2,12 +2,14 @@ from functools import reduce
 from operator import or_
 from typing import Dict
 
+from django.conf import settings
 from django.utils.functional import cached_property
 from django.utils.module_loading import import_string
-from django.conf import settings
 from django_filters.conf import is_callable
 from rest_framework.fields import Field
 from rest_framework.serializers import ModelSerializer, SerializerMetaclass
+
+from pik.bus.settings import ConsumerBusSettingExtender
 
 
 class LazySerializerRegistrationConflict(Exception):
@@ -132,6 +134,7 @@ class ModelSerializerRegistratorMetaclass(SerializerMetaclass):
             raise LazySerializerRegistrationConflict(
                 (new, cls.SERIALIZERS[name]))
         cls.SERIALIZERS[name] = new
+        ConsumerBusSettingExtender(settings, cls.SERIALIZERS).extend()
         return new
 
 

--- a/pik/bus/settings.py
+++ b/pik/bus/settings.py
@@ -127,8 +127,8 @@ class ConsumerBusSettingExtender:
     @property
     def _is_rabbitmq_consumes_rewrite_condition(self):
         return bool(
-                self._is_rabbitmq_account_name_set
-                and self._is_rabbitmq_consumes_set_all)
+            self._is_rabbitmq_account_name_set
+            and self._is_rabbitmq_consumes_set_all)
 
     def extend(self):
         if self._is_rabbitmq_consumes_rewrite_condition:


### PR DESCRIPTION
Consumer: make all queues auto-consume by setting RABBITMQ_CONSUMES='__ALL__' value.

MDM-913